### PR TITLE
Handling promise rejection errors for babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,0 @@
-{
-  "presets": [
-    "next/babel"
-  ],
-  "plugins": [
-    ["transform-define", "./env-config.js"]
-  ]
-}

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,0 +1,8 @@
+const env = {
+  VERSION: require('./package').version
+}
+
+module.exports = {
+  presets: ['next/babel'],
+  plugins: [['transform-define', env]]
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A pay-to-decrypt service using lnd",
   "main": "index.js",
   "scripts": {
-    "dev": "node --harmony_async_iteration server.js",
+    "dev": "node server.js",
     "build": "next build",
     "start": "NODE_ENV=production node --harmony_async_iteration server.js",
     "test": "node_modules/mocha/bin/mocha --exit --harmony_async_iteration test/unit.js"


### PR DESCRIPTION
Removed babelrc's old format and replaced with new. --harmony_async_iteration not required for newer versions of Node.